### PR TITLE
Fix TCREI tab interaction on slide 5

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -140,3 +140,34 @@ body {
 .hide-cursor {
   cursor: none !important;
 }
+
+/* ---- TCREI Tabs ---- */
+.tcrei-tabs button {
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-weight: 500;
+  transition: background-color 0.3s, color 0.3s;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+}
+.tcrei-tabs button.active {
+  background-color: #FF555E;
+  color: #ffffff;
+}
+.tcrei-content {
+  position: relative;
+  height: 8rem;
+  margin-top: 1.5rem;
+}
+.tcrei-pane {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transform: translateX(1rem);
+  transition: opacity 0.4s, transform 0.4s;
+}
+.tcrei-pane.active {
+  opacity: 1;
+  transform: translateX(0);
+}

--- a/index.html
+++ b/index.html
@@ -87,8 +87,19 @@
         <circle cx="492" cy="50" r="24" fill="#fff" stroke="#000" stroke-width="3"/>
         <text x="492" y="55" font-size="18" text-anchor="middle" fill="#000">I</text>
       </svg>
-      <div class="mt-6 flex justify-center gap-10 text-base md:text-xl">
-        <span>Task</span><span>Context</span><span>References</span><span>Evaluate</span><span>Iterate</span>
+      <div class="mt-6 flex justify-center gap-4 text-base md:text-xl tcrei-tabs">
+        <button class="tcrei-tab active" data-target="task">Task</button>
+        <button class="tcrei-tab" data-target="context">Context</button>
+        <button class="tcrei-tab" data-target="references">References</button>
+        <button class="tcrei-tab" data-target="evaluate">Evaluate</button>
+        <button class="tcrei-tab" data-target="iterate">Iterate</button>
+      </div>
+      <div id="tcrei-content" class="tcrei-content w-full max-w-xl text-flash-black text-lg mx-auto">
+        <div id="task" class="tcrei-pane active">Be clear and specific about what you want the AI to do.</div>
+        <div id="context" class="tcrei-pane">Provide background, audience, and constraints.</div>
+        <div id="references" class="tcrei-pane">Give examples or data for more accurate output.</div>
+        <div id="evaluate" class="tcrei-pane">Review the response to ensure it meets your needs.</div>
+        <div id="iterate" class="tcrei-pane">Refine your prompt and repeat for better results.</div>
       </div>
     </div>
   </section>

--- a/js/main.js
+++ b/js/main.js
@@ -144,6 +144,24 @@ document.addEventListener('DOMContentLoaded', () => {
     chatContainer.innerHTML = '';
   });
 
+  // ---- TCREI Tabs Logic ----
+  const tcreiTabs = document.querySelectorAll('.tcrei-tab');
+  const tcreiPanes = document.querySelectorAll('.tcrei-pane');
+  tcreiTabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      const target = tab.getAttribute('data-target');
+      tcreiTabs.forEach(t => t.classList.remove('active'));
+      tab.classList.add('active');
+      tcreiPanes.forEach(pane => {
+        if (pane.id === target) {
+          pane.classList.add('active');
+        } else {
+          pane.classList.remove('active');
+        }
+      });
+    });
+  });
+
   // Initial setup
   showSlide(currentSlide);
 


### PR DESCRIPTION
## Summary
- add CSS for TCREI tabs and content panes
- implement tab markup and content on slide 5
- add JavaScript to switch TCREI descriptions when tabs are clicked

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68499117a8d88329ac9b96e82104763e