### PR TITLE
feat(slides): Add interactive evaluation demo for slide 9

### DIFF
--- a/css/dist/output.css
+++ b/css/dist/output.css
@@ -9,10 +9,12 @@
       "Courier New", monospace;
     --color-gray-100: oklch(96.7% 0.003 264.542);
     --color-gray-400: oklch(70.7% 0.022 261.325);
+    --color-gray-500: oklch(55.1% 0.027 264.364);
     --color-gray-800: oklch(27.8% 0.033 256.848);
     --color-white: #fff;
     --spacing: 0.25rem;
     --container-md: 28rem;
+    --container-xl: 36rem;
     --container-2xl: 42rem;
     --container-3xl: 48rem;
     --container-4xl: 56rem;
@@ -258,6 +260,9 @@
   .min-h-\[50px\] {
     min-height: 50px;
   }
+  .min-h-\[180px\] {
+    min-height: 180px;
+  }
   .min-h-\[220px\] {
     min-height: 220px;
   }
@@ -284,6 +289,9 @@
   }
   .max-w-md {
     max-width: var(--container-md);
+  }
+  .max-w-xl {
+    max-width: var(--container-xl);
   }
   .flex-shrink-0 {
     flex-shrink: 0;
@@ -847,6 +855,12 @@ body {
   .slide {
     padding: 2rem 1.5rem;
   }
+}
+#s9-incorrect-answer.highlight {
+  background-color: #ffe4e6;
+  border-radius: 4px;
+  padding: 0 4px;
+  transition: background-color 0.3s;
 }
 @property --tw-translate-x {
   syntax: "*";

--- a/css/main.css
+++ b/css/main.css
@@ -320,3 +320,11 @@ body {
     padding: 2rem 1.5rem; /* Adjust padding for smaller screens */
   }
 }
+
+/* ---- Slide 9: Evaluate Animation Styles ---- */
+#s9-incorrect-answer.highlight {
+  background-color: #ffe4e6; /* A light red/pink for highlighting */
+  border-radius: 4px;
+  padding: 0 4px;
+  transition: background-color 0.3s;
+}

--- a/index.html
+++ b/index.html
@@ -229,68 +229,85 @@
 
     <!-- Slide 8: References -->
     <section class="slide bg-white flex flex-col justify-center items-start text-left p-12 md:p-16" data-theme="light">
-  <h2 class="text-flash-black font-bold text-4xl md:text-5xl mb-2">References: Show, Don't Just Tell</h2>
-  <p class="text-flash-black text-xl md:text-2xl font-light max-w-4xl mb-12">
-    Provide the AI with examples, data, or links to generate more accurate and relevant outputs. The more context you provide, the more tailored the response.
-  </p>
+      <h2 class="text-flash-black font-bold text-4xl md:text-5xl mb-2">References: Show, Don't Just Tell</h2>
+      <p class="text-flash-black text-xl md:text-2xl font-light max-w-4xl mb-12">
+        Provide the AI with examples, data, or links to generate more accurate and relevant outputs. The more context you provide, the more tailored the response.
+      </p>
 
-  <div id="s8-reference-grid" class="reference-grid w-full">
-    <div class="reference-card">
-      <div class="card-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>
-      </div>
-      <h3 class="card-title">Text & Docs</h3>
-      <p class="card-description">Plain text, Markdown, or document excerpts.</p>
-      <ul class="card-use-cases">
-        <li>Pasting in raw text or documentation.</li>
-        <li>Summarizing articles or reports.</li>
-      </ul>
-    </div>
+      <div id="s8-reference-grid" class="reference-grid w-full">
+        <div class="reference-card">
+          <div class="card-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>
+          </div>
+          <h3 class="card-title">Text & Docs</h3>
+          <p class="card-description">Plain text, Markdown, or document excerpts.</p>
+          <ul class="card-use-cases">
+            <li>Pasting in raw text or documentation.</li>
+            <li>Summarizing articles or reports.</li>
+          </ul>
+        </div>
 
-    <div class="reference-card">
-      <div class="card-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" /></svg>
-      </div>
-      <h3 class="card-title">Code Files</h3>
-      <p class="card-description">Source code from .py, .js, .html, etc.</p>
-      <ul class="card-use-cases">
-        <li>Debugging errors and suggesting fixes.</li>
-        <li>Translating code to another language.</li>
-      </ul>
-    </div>
+        <div class="reference-card">
+          <div class="card-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" /></svg>
+          </div>
+          <h3 class="card-title">Code Files</h3>
+          <p class="card-description">Source code from .py, .js, .html, etc.</p>
+          <ul class="card-use-cases">
+            <li>Debugging errors and suggesting fixes.</li>
+            <li>Translating code to another language.</li>
+          </ul>
+        </div>
 
-    <div class="reference-card">
-      <div class="card-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375" /></svg>
-      </div>
-      <h3 class="card-title">Data Files</h3>
-      <p class="card-description">Structured data like .csv, .json, or .xml.</p>
-      <ul class="card-use-cases">
-        <li>Analyzing data for trends.</li>
-        <li>Generating charts or summaries.</li>
-      </ul>
-    </div>
+        <div class="reference-card">
+          <div class="card-icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375" /></svg>
+          </div>
+          <h3 class="card-title">Data Files</h3>
+          <p class="card-description">Structured data like .csv, .json, or .xml.</p>
+          <ul class="card-use-cases">
+            <li>Analyzing data for trends.</li>
+            <li>Generating charts or summaries.</li>
+          </ul>
+        </div>
 
-    <div class="reference-card">
-      <div class="card-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" /></svg>
+        <div class="reference-card">
+          <div class="card-icon">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" /></svg>
+          </div>
+          <h3 class="card-title">Images</h3>
+          <p class="card-description">Visuals like .jpg, .png, or .svg.</p>
+          <ul class="card-use-cases">
+            <li>Describing an image for alt-text.</li>
+            <li>Suggesting design improvements.</li>
+          </ul>
+        </div>
       </div>
-      <h3 class="card-title">Images</h3>
-      <p class="card-description">Visuals like .jpg, .png, or .svg.</p>
-      <ul class="card-use-cases">
-        <li>Describing an image for alt-text.</li>
-        <li>Suggesting design improvements.</li>
-      </ul>
-    </div>
-  </div>
-</section>
+    </section>
 
     <!-- Slide 9: Evaluate -->
-    <section class="slide bg-white flex flex-col justify-center items-center text-center p-16" data-theme="light">
+    <section class="slide bg-white flex flex-col justify-center items-center text-center p-12" data-theme="light">
       <h2 class="text-flash-black font-bold text-5xl mb-8">Evaluate: Don't Trust, Verify</h2>
-      <p class="text-flash-black text-2xl font-light max-w-3xl mx-auto">
-        Don't take the output at face value. Check it for accuracy, bias, completeness, and usefulness. AI can be confidently wrong, so always keep a human in the loop for critical outputs. Your expertise is what makes the AI output valuable—not the other way around.
-      </p>
+
+      <div class="w-full max-w-3xl mx-auto flex flex-col gap-4 min-h-[180px]">
+        <div id="s9-user-bubble-container" class="flex justify-end opacity-0 transition-all duration-500 transform translate-y-4">
+          <div id="s9-user-bubble" class="bg-gray-100 shadow-md text-gray-800 p-4 rounded-xl max-w-xl text-left text-xl"></div>
+        </div>
+
+        <div id="s9-ai-bubble-container" class="flex justify-start opacity-0 transition-all duration-500 transform translate-y-4">
+          <div id="s9-ai-bubble" class="relative bg-gray-100 shadow-md text-gray-800 p-4 rounded-xl max-w-xl text-left text-xl">
+            <p>The third planet from the sun is <span id="s9-incorrect-answer">Mars</span>.</p>
+          </div>
+        </div>
+      </div>
+
+      <div id="s9-gemini-chatbox" class="w-full max-w-3xl mx-auto mt-6 p-4 rounded-full bg-[#333537] flex items-center">
+        <div class="flex-shrink-0"><img src="assets/gemini-logo.png" alt="Gemini Icon" class="w-6 h-6"></div>
+        <div class="flex-grow text-left text-gray-400 ml-4">
+          <span id="s9-placeholder"></span>
+          <span id="s9-typed-text"></span><span id="s9-cursor" class="opacity-0">|</span>
+        </div>
+      </div>
     </section>
 
     <!-- Slide 10: Iterate -->


### PR DESCRIPTION
This commit implements the fully interactive version of Slide 9, titled "Evaluate: Don't Trust, Verify."

The slide now features a complete, multi-stage animation to visually demonstrate the concept of evaluating AI output. The sequence includes:
- An initial 5-second delay before the prompt is typed out.
- A typewriter effect for the user's prompt.
- The appearance of user and AI chat bubbles, with the AI providing a deliberately incorrect answer.

User interaction has been added, allowing the presenter to use the "ArrowDown" key to first highlight the incorrect answer and then replace it with the correct one. This reinforces the key message of the slide about the importance of human verification.